### PR TITLE
examples: fix healthchecks

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -79,12 +79,10 @@ jobs:
 
       - name: Run tests
         run: |
-          docker-compose ps
-          docker-compose logs
           echo wait 5s for SPDK to start... && sleep 5s
-          docker-compose ps
           docker-compose logs
-          echo docker inspect --format='{{json .State.Health.Status}}' $(docker-compose ps -q)
+          docker-compose ps
+          docker inspect --format='{{json .Name}} - {{json .State.Health.Status}}' $(docker-compose ps -q)
         working-directory: examples/telegraf
 
       - name: Logs

--- a/examples/telegraf/docker-compose.yml
+++ b/examples/telegraf/docker-compose.yml
@@ -23,7 +23,7 @@ services:
             ./rpc.py bdev_malloc_create -b Malloc1 64 512 && \
             ./rpc_http_proxy.py 0.0.0.0 9009 spdkuser spdkpass'
     healthcheck:
-      test: curl --fail --insecure --user spdkuser:spdkpass -X POST http://localhost:9009 || exit 1
+      test: ["CMD-SHELL", "curl --fail --insecure --user spdkuser:spdkpass -X POST -H 'Content-Type: application/json' -d '{\"id\": 1, \"method\": \"bdev_get_bdevs\"}' http://localhost:9009 || exit 1"]
       interval: 6s
       retries: 5
       start_period: 20s
@@ -38,6 +38,12 @@ services:
       - influxdb
     networks:
       - opi
+    healthcheck:
+      test: cat /proc/1/status || exit 1
+      interval: 6s
+      retries: 5
+      start_period: 20s
+      timeout: 10s
 
   grafana:
     image: grafana/grafana:8.4.6
@@ -53,7 +59,7 @@ services:
     networks:
       - opi
     healthcheck:
-      test: curl --fail -s http://localhost:3000/ || exit 1
+      test: wget --no-verbose --tries=1 --spider http://localhost:3000/ || exit 1
       interval: 6s
       timeout: 10s
       retries: 3
@@ -74,7 +80,7 @@ services:
     networks:
       - opi
     healthcheck:
-      test: curl -f http://localhost:8086/ping
+      test: wget --no-verbose --tries=1 --spider http://localhost:8086/ping || exit 1
       interval: 6s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
```
# docker-compose ps
       Name                      Command                  State                        Ports
--------------------------------------------------------------------------------------------------------------
telegraf_grafana_1    /run.sh                          Up (healthy)   0.0.0.0:3000->3000/tcp,:::3000->3000/tcp
telegraf_influxdb_1   /entrypoint.sh influxd           Up (healthy)   0.0.0.0:8086->8086/tcp,:::8086->8086/tcp
telegraf_spdk_1       sh -c echo 2048 > /proc/sy ...   Up (healthy)   0.0.0.0:9009->9009/tcp,:::9009->9009/tcp
telegraf_telegraf_1   /entrypoint.sh telegraf          Up (healthy)   8092/udp, 8094/tcp, 8125/udp
```
Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>