### PR TITLE
sztp: Support running tests on Fedora with podman

### DIFF
--- a/examples/sztp/docker-compose.yml
+++ b/examples/sztp/docker-compose.yml
@@ -51,7 +51,7 @@ services:
   web:
     image: python:3.10.6-slim
     volumes:
-      - ${PWD}/config/my-boot-image.img:/var/lib/misc/my-boot-image.img:ro
+      - ./config/my-boot-image.img:/var/lib/misc/my-boot-image.img:Z,ro
     networks:
       - opi
     command: python3 -m http.server 8082
@@ -73,7 +73,7 @@ services:
       context: .
       dockerfile: Dockerfile.agent
     volumes:
-      - ${PWD}/config/input.json:/tmp/input.json:ro
+      - ./config/input.json:/tmp/input.json:Z,ro
     networks:
       - opi
     command: ['/bin/sh', '-c', 'sleep infinity']

--- a/examples/sztp/tests.sh
+++ b/examples/sztp/tests.sh
@@ -49,14 +49,15 @@ jq -r .\"ietf-sztp-conveyed-info:onboarding-information\".\"post-configuration-s
 jq -r .\"ietf-sztp-conveyed-info:onboarding-information\".\"boot-image\".\"download-uri\"[] /tmp/post_rpc_fixed.json
 jq -r .\"ietf-sztp-conveyed-info:onboarding-information\".\"boot-image\".\"image-verification\"[] /tmp/post_rpc_fixed.json
 
-docker-compose run --rm -T agent curl --fail http://web:8082/var/lib/misc/
+docker-compose exec -T agent curl --fail http://web:8082/var/lib/misc/
 
 # actually go and download the image from the web server
 URL=$(jq -r .\"ietf-sztp-conveyed-info:onboarding-information\".\"boot-image\".\"download-uri\"[0] /tmp/post_rpc_fixed.json)
-docker-compose run --rm -v /tmp:/tmp agent curl --output /tmp/"$(basename "${URL}")" --fail "${URL}"
+BASENAME=$(basename "${URL}")
+docker-compose exec -T agent curl --output "/tmp/${BASENAME}" --fail "${URL}"
 
 # Validate signature
-SIGNATURE=$(openssl dgst -sha256 -c /tmp/"$(basename "${URL}")" | awk '{print $2}')
+SIGNATURE=$(docker-compose exec -T agent bash -c "openssl dgst -sha256 -c \"/tmp/${BASENAME}\" | awk '{print \$2}'")
 jq -r .\"ietf-sztp-conveyed-info:onboarding-information\".\"boot-image\".\"image-verification\"[] /tmp/post_rpc_fixed.json | grep "${SIGNATURE}"
 
 echo "DONE"


### PR DESCRIPTION
Fixes #138

* Proper SELinux support for volume mounts
* Do not use nested docker-compose run, see #138
* Do not use ${PWD} in compose file, breaks on Fedora with podman

Signed-off-by: Steven Royer <sroyer@redhat.com>